### PR TITLE
Navigation support for filepath in file attribute of a Step

### DIFF
--- a/.tours/filepathNavigationTour.tour
+++ b/.tours/filepathNavigationTour.tour
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "tourFile": "supportPathInStepFileProperty.tour",
+  "title": "Support path in Step file property",
+  "description": "Support for path in the step file property and in directory property of the step",
+  "steps": [
+    {
+      "file": "src/main/java/org/uom/lefterisxris/codetour/tours/service/Navigator.java",
+      "description": "tryNavigateToStep will return true if the step file was navigated",
+      "line": 32,
+      "title": "TryNavigate"
+    },
+    {
+      "file": "src/main/java/org/uom/lefterisxris/codetour/tours/service/Navigator.java",
+      "description": "if file in step - since it is optional\r\n\r\ncannot navigate - returns false",
+      "line": 46,
+      "title": "No file in step"
+    },
+    {
+      "file": "src/main/java/org/uom/lefterisxris/codetour/tours/service/Navigator.java",
+      "description": "extract filename from the filepath/filename that is in the step file",
+      "line": 50,
+      "title": "extract step file name"
+    },
+    {
+      "file": "src/main/java/org/uom/lefterisxris/codetour/tours/service/Navigator.java",
+      "description": "step is a file reference, so if the file is a directory it is guranteed to not match",
+      "line": 72,
+      "title": "case directory"
+    },
+    {
+      "file": "src/main/java/org/uom/lefterisxris/codetour/tours/service/Navigator.java",
+      "description": "consider the directory of the step. if specified",
+      "line": 76,
+      "title": "extract step directory"
+    },
+    {
+      "file": "src/main/java/org/uom/lefterisxris/codetour/tours/service/Navigator.java",
+      "description": "construct the file path of the step (with platform-independent path)",
+      "line": 77,
+      "title": "platform-independent stepPath"
+    },
+    {
+      "file": "src/main/java/org/uom/lefterisxris/codetour/tours/service/Navigator.java",
+      "description": "make a platform-independent path from the VirtualFile path in question",
+      "line": 78,
+      "title": "platform-independent filePath"
+    },
+    {
+      "file": "src/main/java/org/uom/lefterisxris/codetour/tours/service/Navigator.java",
+      "description": "since step file path can be relative to the project dir\r\n\r\nthe comparison is based on \"endsWith\"\r\n\r\nso if the file path ends with the stepFilePath it's a match",
+      "line": 80,
+      "title": "endsWith comparison"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # CodeTour Changelog
 
 ## [Unreleased]
+### Added
+- navigation support for directory attribute in step
+- navigation support for file path in step file attribute
 
 ## [0.0.5]
 ### Added


### PR DESCRIPTION
---
name: Locally applying PR to test
about: supporting filepath navigation 
assignees: @Noyloy 

---

**Describe the context of the Pull Request**
Adding support for filepath to be specified in Step.file
Adding support for directory that is specified in Step.directoru

**Link the related Issue(s)**
Improved Support for File Paths #64 -
https://github.com/LefterisXris/CodeTour/issues/64

**Provide logic/implementation explanation**
Instead of looking at step.file as a file name, it can be a filepath as well

so, to support that, the step.file will be combined as: step.directory and step.file

and the comparison/matching of the step file and the file itself is based on whether the step file is a suffix of the actual file filepath.